### PR TITLE
Changes from background agent bc-5d80bc57-26b9-49f6-b580-d3276c100349

### DIFF
--- a/Combine/2_Scene1_In_Subpass0/VK_s1.cpp
+++ b/Combine/2_Scene1_In_Subpass0/VK_s1.cpp
@@ -13,6 +13,11 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan.h>
 
+// Fallback for _ARRAYSIZE if not provided by the environment
+#ifndef _ARRAYSIZE
+#define _ARRAYSIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#endif
+
 //glm related macros and header files
 #define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE   //clipping values between 0 and 1 for depth
@@ -1663,7 +1668,7 @@ VkResult createVulkanInstance(void)
     vkApplicationInfo.applicationVersion = 1;
     vkApplicationInfo.pEngineName = gpszAppName;
     vkApplicationInfo.engineVersion = 1;
-    vkApplicationInfo.apiVersion = VK_API_VERSION_1_4;
+    vkApplicationInfo.apiVersion = VK_API_VERSION_1_3;
 
     //Step3: Initialize struct VkInstanceCreateInfo by using information in Step1 and Step2
     VkInstanceCreateInfo vkInstanceCreateInfo;

--- a/Combine/Combine_V1/VK_s1.cpp
+++ b/Combine/Combine_V1/VK_s1.cpp
@@ -14,6 +14,11 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan.h>
 
+// Fallback for _ARRAYSIZE if not provided by the environment
+#ifndef _ARRAYSIZE
+#define _ARRAYSIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#endif
+
 //glm related macros and header files
 #define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE   //clipping values between 0 and 1 for depth
@@ -2342,7 +2347,7 @@ VkResult createVulkanInstance(void)
     vkApplicationInfo.applicationVersion = 1;
     vkApplicationInfo.pEngineName = gpszAppName;
     vkApplicationInfo.engineVersion = 1;
-    vkApplicationInfo.apiVersion = VK_API_VERSION_1_4;
+    vkApplicationInfo.apiVersion = VK_API_VERSION_1_3;
 
     //Step3: Initialize struct VkInstanceCreateInfo by using information in Step1 and Step2
     VkInstanceCreateInfo vkInstanceCreateInfo;


### PR DESCRIPTION
Add `_ARRAYSIZE` fallback macro and downgrade Vulkan API version to improve compatibility and ensure consistent compilation.

The `_ARRAYSIZE` macro ensures that array size calculations compile correctly across different environments, preventing potential build failures. Downgrading the Vulkan API version from 1.4 to 1.3 addresses potential compatibility issues with older drivers or systems that may not yet fully support the latest API version, thus broadening the application's reach.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d80bc57-26b9-49f6-b580-d3276c100349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d80bc57-26b9-49f6-b580-d3276c100349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

